### PR TITLE
[stacks-blockchain-api]: fix HPA deployment reference

### DIFF
--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -41,4 +41,4 @@ sources:
   - https://github.com/hirosystems/stacks-blockchain-api
   - https://docs.hiro.so/api
   - https://docs.hiro.so/get-started/stacks-blockchain-api
-version: 1.0.3
+version: 1.0.4

--- a/hirosystems/stacks-blockchain-api/templates/api-reader/hpa.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-reader/hpa.yaml
@@ -17,7 +17,7 @@ spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
     kind: Deployment
-    name: {{ include "common.names.fullname" . }}
+    name: {{ include "common.names.fullname" . }}-reader
   minReplicas: {{ .Values.apiReader.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.apiReader.autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
Fixes the API reader's HPA to properly reference the k8s deployment name.