### PR TITLE
[bitcoin-core] enable extraPort in statefulset, rev version

### DIFF
--- a/hirosystems/bitcoin-core/Chart.yaml
+++ b/hirosystems/bitcoin-core/Chart.yaml
@@ -25,4 +25,4 @@ sources:
   - https://github.com/bitcoin/bitcoin
   - https://github.com/ruimarinho/docker-bitcoin-core
   - https://bitcoin.org
-version: 2.0.0
+version: 2.0.1

--- a/hirosystems/bitcoin-core/templates/statefulset.yaml
+++ b/hirosystems/bitcoin-core/templates/statefulset.yaml
@@ -171,9 +171,9 @@ spec:
               containerPort: {{ .Values.containerPorts.rpc }}
             - name: tcp-p2p
               containerPort: {{ .Values.containerPorts.p2p }}
-            { { - if .Values.extraPorts } }
-            { { - include "common.tplvalues.render" (dict "value" .Values.extraPorts "context" $) | nindent 12 } }
-            { { - end } }
+            {{- if .Values.extraPorts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraPorts "context" $) | nindent 12 }}
+            {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}

--- a/hirosystems/bitcoin-core/templates/statefulset.yaml
+++ b/hirosystems/bitcoin-core/templates/statefulset.yaml
@@ -171,6 +171,9 @@ spec:
               containerPort: {{ .Values.containerPorts.rpc }}
             - name: tcp-p2p
               containerPort: {{ .Values.containerPorts.p2p }}
+            { { - if .Values.extraPorts } }
+            { { - include "common.tplvalues.render" (dict "value" .Values.extraPorts "context" $) | nindent 12 } }
+            { { - end } }
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}

--- a/hirosystems/bitcoin-core/values.yaml
+++ b/hirosystems/bitcoin-core/values.yaml
@@ -134,10 +134,6 @@ containerPorts:
   ##
   rpc: 8332
   p2p: 8333
-
-  ## @param service.extraPorts Extra ports to expose in stacks-blockchain container
-  ##
-  extraPorts: []
   ## bitcoin network: testnet
   ##
   # rpc: 18332
@@ -150,6 +146,11 @@ containerPorts:
   ##
   # rpc: 38332
   # p2p: 38333
+
+## @param service.extraPorts Extra ports to expose in stacks-blockchain container
+##
+extraPorts: []
+
 ## Configure extra options for bitcoin-core containers' liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ## @param livenessProbe.enabled Enable livenessProbe on bitcoin-core containers

--- a/hirosystems/bitcoin-core/values.yaml
+++ b/hirosystems/bitcoin-core/values.yaml
@@ -147,7 +147,7 @@ containerPorts:
   # rpc: 38332
   # p2p: 38333
 
-## @param service.extraPorts Extra ports to expose in stacks-blockchain container
+## @param service.extraPorts Extra ports to expose in bitcoin-core container
 ##
 extraPorts: []
 

--- a/hirosystems/bitcoin-core/values.yaml
+++ b/hirosystems/bitcoin-core/values.yaml
@@ -134,6 +134,10 @@ containerPorts:
   ##
   rpc: 8332
   p2p: 8333
+
+  ## @param service.extraPorts Extra ports to expose in stacks-blockchain container
+  ##
+  extraPorts: []
   ## bitcoin network: testnet
   ##
   # rpc: 18332


### PR DESCRIPTION
adding `extraPorts` to bitcoin statefulset.  
it already exists in the service.yaml manifest but not the statefulset.yaml