### PR TITLE
[stacks-blockchain-api] switch to parquet based event replay

### DIFF
--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -41,4 +41,4 @@ sources:
   - https://github.com/hirosystems/stacks-blockchain-api
   - https://docs.hiro.so/api
   - https://docs.hiro.so/get-started/stacks-blockchain-api
-version: 4.1.1
+version: 4.1.2

--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -41,4 +41,4 @@ sources:
   - https://github.com/hirosystems/stacks-blockchain-api
   - https://docs.hiro.so/api
   - https://docs.hiro.so/get-started/stacks-blockchain-api
-version: 4.1.2
+version: 5.0.0

--- a/hirosystems/stacks-blockchain-api/templates/_helpers.tpl
+++ b/hirosystems/stacks-blockchain-api/templates/_helpers.tpl
@@ -1,7 +1,21 @@
 {{/*
+Return the name of the Stacks-Blockchain API Event Replay image name
+*/}}
+{{- define "stacksBlockchainApiEventReplay.image" -}}
+{{ include "common.images.image (dict "imageRoot" .Values.apiWriter.replayEvents.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
 Return the proper Stacks-Blockchain API image name
 */}}
 {{- define "stacksBlockchainApi.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.apiWriter.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper init container used for downloading and parquest file generation image name
+*/}}
+{{- define "stacksEventReplayi.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.apiWriter.image "global" .Values.global) }}
 {{- end -}}
 

--- a/hirosystems/stacks-blockchain-api/templates/_helpers.tpl
+++ b/hirosystems/stacks-blockchain-api/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Return the name of the Stacks-Blockchain API Event Replay image name
+Return the name of the Stacks-Blockchain API Event Replay image name used for the download and replay init containers
 */}}
 {{- define "stacksBlockchainApiEventReplay.image" -}}
 {{ include "common.images.image (dict "imageRoot" .Values.apiWriter.replayEvents.image "global" .Values.global) }}
@@ -9,13 +9,6 @@ Return the name of the Stacks-Blockchain API Event Replay image name
 Return the proper Stacks-Blockchain API image name
 */}}
 {{- define "stacksBlockchainApi.image" -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.apiWriter.image "global" .Values.global) }}
-{{- end -}}
-
-{{/*
-Return the proper init container used for downloading and parquest file generation image name
-*/}}
-{{- define "stacksEventReplayi.image" -}}
 {{ include "common.images.image" (dict "imageRoot" .Values.apiWriter.image "global" .Values.global) }}
 {{- end -}}
 

--- a/hirosystems/stacks-blockchain-api/templates/_helpers.tpl
+++ b/hirosystems/stacks-blockchain-api/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Return the name of the Stacks-Blockchain API Event Replay image name used for the download and replay init containers
 */}}
 {{- define "stacksBlockchainApiEventReplay.image" -}}
-{{ include "common.images.image (dict "imageRoot" .Values.apiWriter.replayEvents.image "global" .Values.global) }}
+{{ include "common.images.image" (dict "imageRoot" .Values.apiWriter.replayEvents.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
@@ -101,7 +101,7 @@ spec:
           {{- if .Values.apiWriter.resources }}
           resources: {{- toYaml .Values.apiWriter.resources | nindent 12 }}
           {{- end }}
-        {{- if .Values.apiWriter.config.exportEvents }}
+        {{- if .Values.apiWriter.config.exportEvents.enabled }}
         - name: export-events
           image: {{ template "stacksBlockchainApi.image" . }}
           imagePullPolicy: {{ .Values.apiWriter.pullPolicy | quote }}
@@ -145,7 +145,29 @@ spec:
               subPath: {{ .Values.apiWriter.persistence.data.subPath }}
               {{- end }}
         {{- end }}
-        {{- if .Values.apiWriter.config.dataArchiveUrl }}
+        {{- if and (.Values.apiWriter.config.exportEvents.enabled) (.Values.apiWriter.config.exportEvents.compressEventsData) }}
+        - name: compress-events-data
+          image: google/cloud-sdk:alpine
+          env:
+            - name: STACKS_EXPORT_EVENTS_PATH
+              value: {{.Values.apiWriter.persistence.data.mountPath}}
+            - name: STACKS_EXPORT_EVENTS_FILE
+              value: {{ .Values.apiWriter.persistence.data.mountPath }}/stacks-node-events.tsv
+          command:
+            - sh
+            - -c
+            - |
+              echo "Installing pigz and tar"
+              apk add pigz tar
+              tar -I pigz -cvf ${STACKS_EXPORT_EVENTS_PATH}/stacks-node-events.tsv.gz ${STACKS_EXPORT_EVENTS_FILE}
+          {{- if .Values.apiWriter.resources}}
+          resources: {{- toYaml .Values.apiWriter.resources | nindent 12}}
+          {{- end}}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.apiWriter.persistence.data.mountPath }}
+        {{- end }}
+        {{- if and (.Values.apiWriter.config.dataArchiveUrl) (eq .Values.apiWriter.config.exportEvents false) }}
         - name: download-archive-data
           image: {{ template "stacksBlockchainApiEventReplay.image" . }}
           imagePullPolicy: {{ .Values.apiWriter.pullPolicy | quote }}

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
@@ -167,7 +167,7 @@ spec:
             - name: data
               mountPath: {{ .Values.apiWriter.persistence.data.mountPath }}
         {{- end }}
-        {{- if and (.Values.apiWriter.config.dataArchiveUrl) (eq .Values.apiWriter.config.exportEvents false) }}
+        {{- if and (.Values.apiWriter.config.dataArchiveUrl) (eq .Values.apiWriter.config.exportEvents.enabled false) }}
         - name: download-archive-data
           image: {{ template "stacksBlockchainApiEventReplay.image" . }}
           imagePullPolicy: {{ .Values.apiWriter.pullPolicy | quote }}

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
@@ -211,7 +211,7 @@ spec:
         {{- end }}
         {{- if .Values.apiWriter.config.replayEvents.enabled }}
         - name: replay-events
-          image: {{ template "stacksBlockchainApiEventReplay.image" . }}
+          image: {{ template "stacksBlockchainApi.image" . }}
           imagePullPolicy: {{ .Values.apiWriter.pullPolicy | quote }}
           env:
             - name: STACKS_API_LOG_LEVEL
@@ -223,7 +223,7 @@ spec:
               value: "0x80000000"
               {{- end }}
             - name: STACKS_EVENTS_DIR
-              value: /hirosystems/api-writer/data/events
+              value: {{ .Values.apiWriter.persistence.data.mountPath }}/events
             - name: PG_DATABASE
               value: {{ include "postgresql.database" .Subcharts.postgresql }}
             - name: PG_SCHEMA
@@ -239,17 +239,14 @@ spec:
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: {{ include "postgresql.adminPasswordKey" .Subcharts.postgresql }}
-                  name: {{ include "postgresql.secretName" .Subcharts.postgresql }}
+                  key: {{ include "postgresql.adminPasswordKey" .Subcharts.postgresql | quote }}
+                  name: {{ include "postgresql.secretName" .Subcharts.postgresql | quote }}
             - name: PG_APPLICATION_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
             - name: PG_CONNECTION_POOL_MAX
               value: {{ default "50" .Values.apiWriter.config.pgConnectionPoolMax | quote }}
-            {{- if .Values.cdn.enabled }}
-            - name: PG_IDENT_INDEX_TYPE
-              value: hash
             {{- if .Values.apiWriter.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -262,10 +259,7 @@ spec:
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.apiWriter.extraEnvVarsSecret "context" $) }}
             {{- end }}
-          command:
-            - sh
-            - -c
-              {{- printf "node ./lib/index.js from-parquet-events --workers=%d" .Values.apiWriter.replayEvents.workers | quote }}
+          command: node ./lib/index.js from-parquet-events --workers={{ .Values.apiWriter.config.replayEvents.workers }}
           {{- if .Values.apiWriter.initContainerSecurityContext.enabled }}
           securityContext: {{- omit .Values.apiWriter.initContainerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
@@ -147,7 +147,7 @@ spec:
         {{- end }}
         {{- if .Values.apiWriter.config.dataArchiveUrl }}
         - name: download-archive-data
-          image: alpine
+          image: {{ template "stacksBlockchainApiEventReplay.image" . }}
           imagePullPolicy: {{ .Values.apiWriter.pullPolicy | quote }}
           env:
             - name: ARCHIVE_URL
@@ -161,7 +161,9 @@ spec:
               if [ -z "$(ls -A "${DATA_DIR}" | grep -v "lost+found")" ]; then
                 echo "Downloading archive"
                 wget ${ARCHIVE_URL} -O ${DATA_DIR}/stacks-node-events.tsv.gz
-                gzip -d ${DATA_DIR}/stacks-node-events.tsv.gz
+                cp -r parquet_generator ${DATA_DIR}
+                cd ${DATA_DIR}
+                python3 -m parquet_generator --tsv-file ${DATA_DIR}/stacks-node-events.tsv.gz
               else
                 echo "Previous data found. Exiting."
               fi
@@ -209,50 +211,61 @@ spec:
         {{- end }}
         {{- if .Values.apiWriter.config.replayEvents.enabled }}
         - name: replay-events
-          image: {{ template "stacksBlockchainApi.image" . }}
+          image: {{ template "stacksBlockchainApiEventReplay.image" . }}
           imagePullPolicy: {{ .Values.apiWriter.pullPolicy | quote }}
           env:
-            - name: STACKS_EXPORT_EVENTS_FILE
-              value: {{ .Values.apiWriter.persistence.data.mountPath }}/stacks-node-events.tsv
+            - name: STACKS_API_LOG_LEVEL
+              value: {{ ternary "debug" "info" (or .Values.apiWriter.image.debug .Values.diagnosticMode.enabled) | quote }}
+            - name: STACKS_CHAIN_ID
+              {{- if eq .Values.blockchainNetwork "mainnet" }}
+              value: "0x00000001"
+              {{- else }}
+              value: "0x80000000"
+              {{- end }}
+            - name: STACKS_EVENTS_DIR
+              value: /hirosystems/api-writer/data/events
+            - name: PG_DATABASE
+              value: {{ include "postgresql.database" .Subcharts.postgresql }}
+            - name: PG_SCHEMA
+              value: {{ include "postgresql.database" .Subcharts.postgresql }}
+            - name: PG_PRIMARY_HOST
+              value: {{ include "postgresql.primary.fullname" .Subcharts.postgresql }}
             - name: PG_HOST
               value: {{ include "common.names.fullname" .Subcharts.postgresql }}-all
             - name: PG_PORT
               value: {{ include "postgresql.service.port" .Subcharts.postgresql | quote }}
             - name: PG_USER
               value: {{ include "stacksBlockchainApi.postgresql.username" . }}
-            - name: PG_DATABASE
-              value: {{ include "postgresql.database" .Subcharts.postgresql | quote }}
-            - name: PG_SCHEMA
-              value: {{ include "postgresql.database" .Subcharts.postgresql }}
-            - name: PG_CONNECTION_POOL_MAX
-              value: {{ .Values.apiWriter.config.pgConnectionPoolMax | quote }}
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: {{ include "postgresql.adminPasswordKey" .Subcharts.postgresql | quote }}
-                  name: {{ include "postgresql.secretName" .Subcharts.postgresql | quote }}
+                  key: {{ include "postgresql.adminPasswordKey" .Subcharts.postgresql }}
+                  name: {{ include "postgresql.secretName" .Subcharts.postgresql }}
+            - name: PG_APPLICATION_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: PG_CONNECTION_POOL_MAX
+              value: {{ default "50" .Values.apiWriter.config.pgConnectionPoolMax | quote }}
+            {{- if .Values.cdn.enabled }}
             - name: PG_IDENT_INDEX_TYPE
               value: hash
-            - name: NODE_ENV
-              value: production
-            - name: BNS_IMPORT_DIR
-              value: {{ .Values.apiWriter.persistence.bns.mountPath }}
-            - name: STACKS_API_EVENT_REPLAY_LOG_LEVEL
-              value: debug
-            - name: STACKS_API_ENABLE_FT_METADATA
-              value: {{ ternary "1" "0" .Values.apiWriter.config.enableFtMetadata | quote }}
-            - name: STACKS_API_ENABLE_NFT_METADATA
-              value: {{ ternary "1" "0" .Values.apiWriter.config.enableNftMetadata | quote }}
+            {{- if .Values.apiWriter.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.apiWriter.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.apiWriter.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.apiWriter.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.apiWriter.extraEnvVarsSecret "context" $) }}
+            {{- end }}
           command:
             - sh
             - -c
-            {{- if .Values.apiWriter.config.replayEvents.prunedMode }}
-            - |
-              node ./lib/index.js import-events --file ${STACKS_EXPORT_EVENTS_FILE} --wipe-db --force --mode pruned
-            {{- else }}
-            - |
-              node ./lib/index.js import-events --file ${STACKS_EXPORT_EVENTS_FILE} --wipe-db --force
-            {{- end }}
+              {{- printf "node ./lib/index.js from-parquet-events --workers=%d" .Values.apiWriter.replayEvents.workers | quote }}
           {{- if .Values.apiWriter.initContainerSecurityContext.enabled }}
           securityContext: {{- omit .Values.apiWriter.initContainerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
@@ -214,6 +214,8 @@ spec:
           image: {{ template "stacksBlockchainApi.image" . }}
           imagePullPolicy: {{ .Values.apiWriter.pullPolicy | quote }}
           env:
+            - name: --max-old-space-size
+              value: {{ .Values.apiWriter.config.replayEvents.maxOldSize }}
             - name: STACKS_API_LOG_LEVEL
               value: {{ ternary "debug" "info" (or .Values.apiWriter.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: STACKS_CHAIN_ID
@@ -259,12 +261,18 @@ spec:
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.apiWriter.extraEnvVarsSecret "context" $) }}
             {{- end }}
-          command: node ./lib/index.js from-parquet-events --workers={{ .Values.apiWriter.config.replayEvents.workers }}
+          command:
+          - node
+          args:
+          - "./lib/index.js"
+          - "from-parquet-events"
+          - {{ printf "--workers=%d" (int .Values.apiWriter.config.replayEvents.workers) | quote }}
+          - {{ printf "--max-old-space-size=%d" (int .Values.apiWriter.config.replayEvents.maxOldSize) | quote }}
           {{- if .Values.apiWriter.initContainerSecurityContext.enabled }}
           securityContext: {{- omit .Values.apiWriter.initContainerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.apiWriter.resources }}
-          resources: {{- toYaml .Values.apiWriter.resources | nindent 12 }}
+          {{- if .Values.apiWriter.config.replayEvents.resources }}
+          resources: {{- toYaml .Values.apiWriter.config.replayEvents.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: data

--- a/hirosystems/stacks-blockchain-api/values.yaml
+++ b/hirosystems/stacks-blockchain-api/values.yaml
@@ -76,7 +76,11 @@ apiWriter:
     # CAUTION: THIS WILL WIPE YOUR CURRENT DATABASE
     replayEvents:
       enabled: false
-      prunedMode: true
+      image:
+        registry: docker.io
+        repository: hirosystems/stacks-event-replay
+        tag: 1.0.2
+      workers: 4
     exportEvents: false
     enableFtMetadata: true
     enableNftMetadata: false

--- a/hirosystems/stacks-blockchain-api/values.yaml
+++ b/hirosystems/stacks-blockchain-api/values.yaml
@@ -75,12 +75,22 @@ apiWriter:
     # Replay events from the API's TSV file into the Postgres database
     # CAUTION: THIS WILL WIPE YOUR CURRENT DATABASE
     replayEvents:
-      enabled: false
+      enabled: true
       image:
         registry: docker.io
         repository: hirosystems/stacks-event-replay
         tag: 1.0.2
       workers: 4
+      maxOldSize: 8192
+      resources:
+        # limits:
+        #   memory: 1.5Gi
+        # requests:
+        #   cpu: 100m
+        #   memory: 1.5Gi
+        limits: {}
+        requests:
+          memory: 32Gi
     exportEvents: false
     enableFtMetadata: true
     enableNftMetadata: false

--- a/hirosystems/stacks-blockchain-api/values.yaml
+++ b/hirosystems/stacks-blockchain-api/values.yaml
@@ -75,8 +75,7 @@ apiWriter:
     # Replay events from the API's TSV file into the Postgres database
     # CAUTION: THIS WILL WIPE YOUR CURRENT DATABASE
 
-    # Note: both exportEvents.enabled and exportEvents.compressEventsData should be set to 'true' in most common situations
-    # followed by replayEvents also set to 'true'
+    # Note: exportEvents.compressEventsData should be set to 'true' when you intend to replayEvents immediately after
     exportEvents:
       enabled:  false
       compressEventsData: false

--- a/hirosystems/stacks-blockchain-api/values.yaml
+++ b/hirosystems/stacks-blockchain-api/values.yaml
@@ -74,8 +74,14 @@ apiWriter:
     # dataArchiveUrl: https://storage.googleapis.com/hirosystems-archive/mainnet/api/mainnet-blockchain-api-5.0.0-latest.tar.gz
     # Replay events from the API's TSV file into the Postgres database
     # CAUTION: THIS WILL WIPE YOUR CURRENT DATABASE
+
+    # Note: both exportEvents.enabled and exportEvents.compressEventsData should be set to 'true' in most common situations
+    # followed by replayEvents also set to 'true'
+    exportEvents:
+      enabled:  false
+      compressEventsData: false
     replayEvents:
-      enabled: true
+      enabled: false
       image:
         registry: docker.io
         repository: hirosystems/stacks-event-replay
@@ -91,7 +97,6 @@ apiWriter:
         limits: {}
         requests:
           memory: 32Gi
-    exportEvents: false
     enableFtMetadata: true
     enableNftMetadata: false
     bindAddress: "0.0.0.0"


### PR DESCRIPTION
- download and replay init container using `stacks-event-replay` pod
- update api chart version to 4.1.2