### PR TITLE
fix: max old space and remove unused argument

### DIFF
--- a/hirosystems/stacks-blockchain-api/Chart.lock
+++ b/hirosystems/stacks-blockchain-api/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 12.12.10
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.13.3
-digest: sha256:e92d8594e35b2f1807661f0474e5ac1a2deaac8a53493a6b6a94c0525651b78d
-generated: "2023-10-25T12:35:40.790461-04:00"
+  version: 2.13.4
+digest: sha256:fd38f9210e9d3df51df7faad5dfabd1711120840fc90be25b5d9c6bf58da6fcf
+generated: "2023-12-15T10:34:06.093471-05:00"

--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -41,4 +41,4 @@ sources:
   - https://github.com/hirosystems/stacks-blockchain-api
   - https://docs.hiro.so/api
   - https://docs.hiro.so/get-started/stacks-blockchain-api
-version: 5.0.1
+version: 5.0.2

--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: ApplicationServer
 apiVersion: v2
-appVersion: 7.3.2
+appVersion: 7.3.6
 dependencies:
   - condition: stacks-blockchain.enabled
     name: stacks-blockchain
@@ -41,4 +41,4 @@ sources:
   - https://github.com/hirosystems/stacks-blockchain-api
   - https://docs.hiro.so/api
   - https://docs.hiro.so/get-started/stacks-blockchain-api
-version: 5.0.0
+version: 5.0.1

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
@@ -290,6 +290,7 @@ spec:
           args:
           - "./lib/index.js"
           - "from-parquet-events"
+          - {{ printf "--workers=%d" (int .Values.apiWriter.config.replayEvents.workers) | quote }}
           {{- if .Values.apiWriter.initContainerSecurityContext.enabled }}
           securityContext: {{- omit .Values.apiWriter.initContainerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
@@ -271,6 +271,8 @@ spec:
                   fieldPath: metadata.name
             - name: PG_CONNECTION_POOL_MAX
               value: {{ default "50" .Values.apiWriter.config.pgConnectionPoolMax | quote }}
+            - name: NODE_OPTIONS
+              value: {{ printf "--max-old-space-size=%d" (int .Values.apiWriter.config.replayEvents.maxOldSize) | quote }}
             {{- if .Values.apiWriter.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -288,8 +290,6 @@ spec:
           args:
           - "./lib/index.js"
           - "from-parquet-events"
-          - {{ printf "--workers=%d" (int .Values.apiWriter.config.replayEvents.workers) | quote }}
-          - {{ printf "--max-old-space-size=%d" (int .Values.apiWriter.config.replayEvents.maxOldSize) | quote }}
           {{- if .Values.apiWriter.initContainerSecurityContext.enabled }}
           securityContext: {{- omit .Values.apiWriter.initContainerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}

--- a/hirosystems/stacks-blockchain-api/values.yaml
+++ b/hirosystems/stacks-blockchain-api/values.yaml
@@ -85,6 +85,7 @@ apiWriter:
         registry: docker.io
         repository: hirosystems/stacks-event-replay
         tag: 1.0.2
+      workers: 4
       maxOldSize: 8192
       resources:
         # limits:

--- a/hirosystems/stacks-blockchain-api/values.yaml
+++ b/hirosystems/stacks-blockchain-api/values.yaml
@@ -85,7 +85,6 @@ apiWriter:
         registry: docker.io
         repository: hirosystems/stacks-event-replay
         tag: 1.0.2
-      workers: 4
       maxOldSize: 8192
       resources:
         # limits:
@@ -114,7 +113,7 @@ apiWriter:
   image:
     registry: docker.io
     repository: hirosystems/stacks-blockchain-api
-    tag: 7.3.2
+    tag: 7.3.6
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -610,7 +609,7 @@ apiReader:
   image:
     registry: docker.io
     repository: hirosystems/stacks-blockchain-api
-    tag: 7.3.2
+    tag: 7.3.6
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -968,7 +967,7 @@ apiRosettaReader:
   image:
     registry: docker.io
     repository: hirosystems/stacks-blockchain-api
-    tag: 7.3.2
+    tag: 7.3.6
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
* Fixes the max old space arg by placing it in the NODE_OPTIONS env var, otherwise it's not acknowledged
* Despite the [replay docs](https://github.com/hirosystems/stacks-event-replay/blob/7b9b453bc0aa72038cfb046899c48c767ebd5a3a/README.md?plain=1#L43), there is no valid `workers` argument for the `from-parquet-events` [function](https://github.com/hirosystems/stacks-blockchain-api/blob/faa5febfbc15224b3cfc24373721c33ae6aa06f0/src/index.ts#L281-L286). There is also no `PARALLEL_WORKERS` env var acknowledged in the API.
  * @csgui is there supposed to be a `workers` argument?