### PR TITLE
[stacks-blockchain]: allow pvc specific labels

### DIFF
--- a/hirosystems/stacks-blockchain/Chart.yaml
+++ b/hirosystems/stacks-blockchain/Chart.yaml
@@ -33,4 +33,4 @@ name: stacks-blockchain
 sources:
   - https://github.com/stacks-network/stacks-blockchain
   - https://docs.stacks.co/
-version: 2.1.1
+version: 2.1.2

--- a/hirosystems/stacks-blockchain/templates/statefulset.yaml
+++ b/hirosystems/stacks-blockchain/templates/statefulset.yaml
@@ -271,7 +271,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
           {{- end }}
           {{- if .Values.persistence.labels }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.persistence.labels "context" $) | nindent 10 }}
           {{- end }}
       spec:
         accessModes:

--- a/hirosystems/stacks-blockchain/templates/statefulset.yaml
+++ b/hirosystems/stacks-blockchain/templates/statefulset.yaml
@@ -266,9 +266,13 @@ spec:
           {{- if .Values.commonAnnotations }}
           {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
           {{- end }}
-        {{- if .Values.commonLabels }}
-        labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
-        {{- end }}
+        labels:
+          {{- if .Values.commonLabels }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
+          {{- end }}
+          {{- if .Values.persistence.labels }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+          {{- end }}
       spec:
         accessModes:
         {{- range .Values.persistence.accessModes }}

--- a/hirosystems/stacks-blockchain/values.yaml
+++ b/hirosystems/stacks-blockchain/values.yaml
@@ -602,6 +602,9 @@ persistence:
   annotations: {}
   ## @param persistence.accessModes Persistent Volume Access Modes
   ##
+  ## @param persistence.annotations Persistent Volume Claim labels
+  ##
+  labels: {}
   accessModes:
     - ReadWriteOnce
   ## @param persistence.size Size of data volume


### PR DESCRIPTION
to better support pvc-autoresizer, it would make sense to allow specific labels to be added to only the PVC and not have to user the `commonLabels` param which would be applied to all the resourses.