### PR TITLE
feat(stacks-blockchain-api): make the psql subchart optional

### DIFF
--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -41,4 +41,4 @@ sources:
   - https://github.com/hirosystems/stacks-blockchain-api
   - https://docs.hiro.so/api
   - https://docs.hiro.so/get-started/stacks-blockchain-api
-version: 6.0.0
+version: 6.1.0

--- a/hirosystems/stacks-blockchain-api/templates/api-reader/deployment.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-reader/deployment.yaml
@@ -126,6 +126,7 @@ spec:
               value: {{ ternary "1" "0" .Values.apiReader.config.enableNftMetadata | quote }}
             - name: STACKS_ADDRESS_CACHE_SIZE
               value: {{ default "50000" .Values.apiReader.config.stacksAddressCacheSize | quote }}
+            {{- if .Values.postgresql.enabled }}
             - name: PG_DATABASE
               value: {{ include "postgresql.v1.database" .Subcharts.postgresql }}
             - name: PG_SCHEMA
@@ -143,6 +144,7 @@ spec:
                 secretKeyRef:
                   key: {{ include "postgresql.v1.adminPasswordKey" .Subcharts.postgresql }}
                   name: {{ include "postgresql.v1.secretName" .Subcharts.postgresql }}
+            {{- end }}
             - name: PG_APPLICATION_NAME
               valueFrom:
                 fieldRef:

--- a/hirosystems/stacks-blockchain-api/templates/api-rosetta-reader/deployment.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-rosetta-reader/deployment.yaml
@@ -126,6 +126,7 @@ spec:
               value: {{ ternary "1" "0" .Values.apiRosettaReader.config.enableNftMetadata | quote }}
             - name: STACKS_ADDRESS_CACHE_SIZE
               value: {{ default "50000" .Values.apiRosettaReader.config.stacksAddressCacheSize | quote }}
+            {{- if .Values.postgresql.enabled }}
             - name: PG_DATABASE
               value: {{ include "postgresql.v1.database" .Subcharts.postgresql }}
             - name: PG_SCHEMA
@@ -147,6 +148,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- end }}
             - name: PG_CONNECTION_POOL_MAX
               value: {{ default "50" .Values.apiRosettaReader.config.pgConnectionPoolMax | quote }}
             - name: PG_STATEMENT_TIMEOUT

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
@@ -116,17 +116,19 @@ spec:
               value: {{ include "postgresql.v1.service.port" .Subcharts.postgresql | quote }}
             - name: PG_USER
               value: {{ include "stacksBlockchainApi.postgresql.username" . }}
+            {{- if .Values.postgresql.enabled }}
             - name: PG_DATABASE
               value: {{ include "postgresql.v1.database" .Subcharts.postgresql | quote }}
             - name: PG_SCHEMA
               value: {{ include "postgresql.v1.database" .Subcharts.postgresql }}
-            - name: PG_CONNECTION_POOL_MAX
-              value: {{ .Values.apiWriter.config.pgConnectionPoolMax | quote }}
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: {{ include "postgresql.v1.adminPasswordKey" .Subcharts.postgresql | quote }}
                   name: {{ include "postgresql.v1.secretName" .Subcharts.postgresql | quote }}
+            {{- end }}
+            - name: PG_CONNECTION_POOL_MAX
+              value: {{ .Values.apiWriter.config.pgConnectionPoolMax | quote }}
             - name: DATA_DIR
               value: {{ .Values.apiWriter.persistence.data.mountPath }}
           command:
@@ -363,6 +365,7 @@ spec:
               value: {{ default "50000" .Values.apiWriter.config.stacksAddressCacheSize | quote }}
             - name: STACKS_API_TOKEN_METADATA_STRICT_MODE
               value: {{ ternary "1" "0" .Values.apiWriter.config.enableTokenMetadataStrictMode | quote }}
+            {{- if .Values.postgresql.enabled }}
             - name: PG_DATABASE
               value: {{ include "postgresql.v1.database" .Subcharts.postgresql }}
             - name: PG_SCHEMA
@@ -380,6 +383,7 @@ spec:
                 secretKeyRef:
                   key: {{ include "postgresql.v1.adminPasswordKey" .Subcharts.postgresql }}
                   name: {{ include "postgresql.v1.secretName" .Subcharts.postgresql }}
+            {{- end }}
             - name: PG_APPLICATION_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Makes the postgresql subchart optional. Disabling it will no longer generate template errors.