### PR TITLE
feat(stacks-blockchain-api): make the stacks-blockchain subchart optional

### DIFF
--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -41,4 +41,4 @@ sources:
   - https://github.com/hirosystems/stacks-blockchain-api
   - https://docs.hiro.so/api
   - https://docs.hiro.so/get-started/stacks-blockchain-api
-version: 6.1.0
+version: 6.2.0

--- a/hirosystems/stacks-blockchain-api/templates/api-reader/deployment.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-reader/deployment.yaml
@@ -116,10 +116,12 @@ spec:
               value: {{ default "0.0.0.0" .Values.apiReader.config.bindAddress | quote }}
             - name: STACKS_PROFILER_PORT
               value: {{ default "9119" .Values.apiReader.containerPorts.profiler | quote }}
+            {{- if (index .Values "stacks-blockchain").enabled }}
             - name: STACKS_CORE_RPC_HOST
               value: {{ include "stacksBlockchain.service.name" (index .Subcharts "stacks-blockchain") }}
             - name: STACKS_CORE_RPC_PORT
               value: {{ include "stacksBlockchain.service.ports.rpc" (index .Subcharts "stacks-blockchain") | quote }}
+            {{- end }}
             - name: STACKS_API_ENABLE_FT_METADATA
               value: {{ ternary "1" "0" .Values.apiReader.config.enableFtMetadata | quote }}
             - name: STACKS_API_ENABLE_NFT_METADATA

--- a/hirosystems/stacks-blockchain-api/templates/api-rosetta-reader/deployment.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-rosetta-reader/deployment.yaml
@@ -116,10 +116,12 @@ spec:
               value: {{ default "0.0.0.0" .Values.apiRosettaReader.config.bindAddress | quote }}
             - name: STACKS_PROFILER_PORT
               value: {{ default "9119" .Values.apiRosettaReader.containerPorts.profiler | quote }}
+            {{- if (index .Values "stacks-blockchain").enabled }}
             - name: STACKS_CORE_RPC_HOST
               value: {{ include "stacksBlockchain.service.name" (index .Subcharts "stacks-blockchain") }}
             - name: STACKS_CORE_RPC_PORT
               value: {{ include "stacksBlockchain.service.ports.rpc" (index .Subcharts "stacks-blockchain") | quote }}
+            {{- end }}
             - name: STACKS_API_ENABLE_FT_METADATA
               value: {{ ternary "1" "0" .Values.apiRosettaReader.config.enableFtMetadata | quote }}
             - name: STACKS_API_ENABLE_NFT_METADATA

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
@@ -353,10 +353,12 @@ spec:
               value: {{ default "0.0.0.0" .Values.apiWriter.config.bindAddress | quote }}
             - name: STACKS_PROFILER_PORT
               value: {{ default "9119" .Values.apiWriter.containerPorts.profiler | quote }}
+            {{- if (index .Values "stacks-blockchain").enabled }}
             - name: STACKS_CORE_RPC_HOST
               value: {{ include "stacksBlockchain.service.name" (index .Subcharts "stacks-blockchain") }}
             - name: STACKS_CORE_RPC_PORT
               value: {{ include "stacksBlockchain.service.ports.rpc" (index .Subcharts "stacks-blockchain") | quote }}
+            {{- end }}
             - name: STACKS_API_ENABLE_FT_METADATA
               value: {{ ternary "1" "0" .Values.apiWriter.config.enableFtMetadata | quote }}
             - name: STACKS_API_ENABLE_NFT_METADATA


### PR DESCRIPTION
Closes https://github.com/hirosystems/devops/issues/2017
Makes the postgresql subchart optional. Disabling it will no longer generate template errors.