### PR TITLE
feat(stacks-blockchain-api): upgrade version, update env vars and order

### DIFF
--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: ApplicationServer
 apiVersion: v2
-appVersion: 8.11.1
+appVersion: 8.11.2
 dependencies:
   - condition: stacks-blockchain.enabled
     name: stacks-blockchain
@@ -41,4 +41,4 @@ sources:
   - https://github.com/hirosystems/stacks-blockchain-api
   - https://docs.hiro.so/api
   - https://docs.hiro.so/get-started/stacks-blockchain-api
-version: 6.3.0
+version: 6.4.0

--- a/hirosystems/stacks-blockchain-api/templates/api-reader/deployment.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-reader/deployment.yaml
@@ -94,8 +94,11 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.apiReader.args "context" $) | nindent 12 }}
           {{- end }}
           env:
-            - name: STACKS_READ_ONLY_MODE
-              value: "true"
+            {{- if .Values.apiReader.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.apiReader.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+            - name: STACKS_API_MODE
+              value: "readonly"
             - name: STACKS_API_LOG_LEVEL
               value: {{ ternary "debug" "info" (or .Values.apiReader.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: STACKS_CHAIN_ID
@@ -166,9 +169,6 @@ spec:
             {{- end }}
             - name: NODE_ENV
               value: production
-            {{- if .Values.apiReader.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.apiReader.extraEnvVars "context" $) | nindent 12 }}
-            {{- end }}
           envFrom:
             {{- if .Values.apiReader.extraEnvVarsCM }}
             - configMapRef:

--- a/hirosystems/stacks-blockchain-api/templates/api-rosetta-reader/deployment.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-rosetta-reader/deployment.yaml
@@ -94,8 +94,11 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.apiRosettaReader.args "context" $) | nindent 12 }}
           {{- end }}
           env:
-            - name: STACKS_READ_ONLY_MODE
-              value: "true"
+            {{- if .Values.apiRosettaReader.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.apiRosettaReader.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+            - name: STACKS_API_MODE
+              value: "readonly"
             - name: STACKS_API_LOG_LEVEL
               value: {{ ternary "debug" "info" (or .Values.apiRosettaReader.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: STACKS_CHAIN_ID
@@ -166,9 +169,6 @@ spec:
             {{- end }}
             - name: NODE_ENV
               value: production
-            {{- if .Values.apiRosettaReader.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.apiRosettaReader.extraEnvVars "context" $) | nindent 12 }}
-            {{- end }}
           envFrom:
             {{- if .Values.apiRosettaReader.extraEnvVarsCM }}
             - configMapRef:

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/statefulset.yaml
@@ -331,6 +331,9 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.args "context" $) | nindent 12 }}
           {{- end }}
           env:
+            {{- if .Values.apiWriter.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
             - name: STACKS_API_LOG_LEVEL
               value: {{ ternary "debug" "info" (or .Values.apiWriter.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: STACKS_CHAIN_ID
@@ -363,8 +366,6 @@ spec:
               value: {{ ternary "1" "0" .Values.apiWriter.config.enableNftMetadata | quote }}
             - name: STACKS_ADDRESS_CACHE_SIZE
               value: {{ default "50000" .Values.apiWriter.config.stacksAddressCacheSize | quote }}
-            - name: STACKS_API_TOKEN_METADATA_STRICT_MODE
-              value: {{ ternary "1" "0" .Values.apiWriter.config.enableTokenMetadataStrictMode | quote }}
             - name: PG_DATABASE
               value: {{ include "stacksBlockchainApi.postgresql.database" . }}
             - name: PG_SCHEMA
@@ -406,9 +407,6 @@ spec:
             {{- if .Values.apiWriter.config.bns.enabled }}
             - name: BNS_IMPORT_DIR
               value: {{ .Values.apiWriter.persistence.bns.mountPath }}
-            {{- end }}
-            {{- if .Values.apiWriter.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
             {{- if .Values.apiWriter.extraEnvVarsCM }}

--- a/hirosystems/stacks-blockchain-api/values.yaml
+++ b/hirosystems/stacks-blockchain-api/values.yaml
@@ -103,7 +103,6 @@ apiWriter:
     enableFtMetadata: true
     enableNftMetadata: false
     bindAddress: "0.0.0.0"
-    enableTokenMetadataStrictMode: true
     pgConnectionPoolMax: "50"
     stacksAddressCacheSize: "50000"
   ## Hiro Systems Stacks Blockchain API Writer image
@@ -118,7 +117,7 @@ apiWriter:
   image:
     registry: docker.io
     repository: hirosystems/stacks-blockchain-api
-    tag: 8.11.1
+    tag: 8.11.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -614,7 +613,7 @@ apiReader:
   image:
     registry: docker.io
     repository: hirosystems/stacks-blockchain-api
-    tag: 8.11.1
+    tag: 8.11.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -973,7 +972,7 @@ apiRosettaReader:
   image:
     registry: docker.io
     repository: hirosystems/stacks-blockchain-api
-    tag: 8.11.1
+    tag: 8.11.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
* Updates Stacks Blockchain API tag
* Moves `extraEnvVars` block to top of `env` list, allowing chart-maintained env vars to reference values in manually-added extra env vars
* Removes `STACKS_API_TOKEN_METADATA_STRICT_MODE` as this is no longer an valid env var
* Updates `STACKS_READ_ONLY_MODE` to newer `STACKS_API_MODE`