### PR TITLE
feat(stacks-blockchain-api): api writer can be deployed as Deployment

### DIFF
--- a/hirosystems/stacks-blockchain-api/Chart.lock
+++ b/hirosystems/stacks-blockchain-api/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 12.12.10
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.31.3
-digest: sha256:56abfc1643734715c1bd35784576ff92fd7704c40d01406952a0e49a6c479c7c
-generated: "2025-08-11T12:10:04.720201-04:00"
+  version: 2.31.4
+digest: sha256:befe817bdae4a8ef4bcc6551ad4052e819f0f710eaf7605b7e7f34bc55b392b2
+generated: "2025-10-21T12:20:46.739769-04:00"

--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: ApplicationServer
 apiVersion: v2
-appVersion: 8.12.0
+appVersion: 8.13.2
 dependencies:
   - condition: stacks-blockchain.enabled
     name: stacks-blockchain
@@ -41,4 +41,4 @@ sources:
   - https://github.com/hirosystems/stacks-blockchain-api
   - https://docs.hiro.so/api
   - https://docs.hiro.so/get-started/stacks-blockchain-api
-version: 6.4.3
+version: 6.5.0

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/persistentvolumeclaim.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/persistentvolumeclaim.yaml
@@ -1,0 +1,77 @@
+{{- if and .Values.apiWriter.enabled (eq .Values.apiWriter.workloadType "Deployment") }}
+{{- if and .Values.apiWriter.persistence.data.enabled (not .Values.apiWriter.persistence.data.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data-{{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: stacks-blockchain-api
+    hiro.so/stacks-blockchain-api-role: rw
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.apiWriter.persistence.data.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.apiWriter.persistence.data.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.persistence.data.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+  {{- range .Values.apiWriter.persistence.data.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.apiWriter.persistence.data.size | quote }}
+  {{- if .Values.apiWriter.persistence.data.selector }}
+  selector: {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.persistence.data.selector "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.apiWriter.persistence.data.dataSource }}
+  dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.persistence.data.dataSource "context" $) | nindent 4 }}
+  {{- end }}
+  {{- include "common.storage.class" (dict "persistence" .Values.apiWriter.persistence.data "global" .Values.global) | nindent 2 }}
+---
+{{- end }}
+{{- if and .Values.apiWriter.persistence.bns.enabled (not .Values.apiWriter.persistence.bns.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bns-data-{{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: stacks-blockchain-api
+    hiro.so/stacks-blockchain-api-role: rw
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.apiWriter.persistence.bns.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.apiWriter.persistence.bns.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.persistence.bns.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+  {{- range .Values.apiWriter.persistence.bns.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.apiWriter.persistence.bns.size | quote }}
+  {{- if .Values.apiWriter.persistence.bns.selector }}
+  selector: {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.persistence.bns.selector "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.apiWriter.persistence.bns.dataSource }}
+  dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.apiWriter.persistence.bns.dataSource "context" $) | nindent 4 }}
+  {{- end }}
+  {{- include "common.storage.class" (dict "persistence" .Values.apiWriter.persistence.bns "global" .Values.global) | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/hirosystems/stacks-blockchain-api/templates/api-writer/workload.yaml
+++ b/hirosystems/stacks-blockchain-api/templates/api-writer/workload.yaml
@@ -1,6 +1,11 @@
 {{- if .Values.apiWriter.enabled }}
+{{- if eq .Values.apiWriter.workloadType "Deployment" }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+{{- else }}
 apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
+{{- end }}
 metadata:
   name: {{ template "common.names.fullname" . }}-rw
   namespace: {{ include "common.names.namespace" . | quote }}
@@ -15,14 +20,22 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if ne .Values.apiWriter.workloadType "Deployment" }}
   podManagementPolicy: {{ .Values.podManagementPolicy | quote }}
+  {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: stacks-blockchain-api
       hiro.so/stacks-blockchain-api-role: rw
+  {{- if ne .Values.apiWriter.workloadType "Deployment" }}
   serviceName: {{ template "common.names.fullname" . }}
+  {{- end }}
   {{- if .Values.apiWriter.updateStrategy }}
+  {{- if eq .Values.apiWriter.workloadType "Deployment" }}
+  strategy: {{- toYaml .Values.apiWriter.updateStrategy | nindent 4 }}
+  {{- else }}
   updateStrategy: {{- toYaml .Values.apiWriter.updateStrategy | nindent 4 }}
+  {{- end }}
   {{- end }}
   template:
     metadata:
@@ -483,6 +496,9 @@ spec:
         {{- if and .Values.apiWriter.persistence.data.enabled .Values.apiWriter.persistence.data.existingClaim }}
           persistentVolumeClaim:
             claimName: {{ tpl .Values.apiWriter.persistence.data.existingClaim . }}
+        {{- else if and .Values.apiWriter.persistence.data.enabled (eq .Values.apiWriter.workloadType "Deployment") }}
+          persistentVolumeClaim:
+            claimName: data-{{ template "common.names.fullname" . }}
         {{- else if not .Values.apiWriter.persistence.data.enabled }}
           emptyDir: {}
         {{- end }}
@@ -490,10 +506,13 @@ spec:
         {{- if and .Values.apiWriter.persistence.bns.enabled .Values.apiWriter.persistence.bns.existingClaim }}
           persistentVolumeClaim:
             claimName: {{ tpl .Values.apiWriter.persistence.bns.existingClaim . }}
+        {{- else if and .Values.apiWriter.persistence.bns.enabled (eq .Values.apiWriter.workloadType "Deployment") }}
+          persistentVolumeClaim:
+            claimName: bns-data-{{ template "common.names.fullname" . }}
         {{- else if not .Values.apiWriter.persistence.bns.enabled }}
           emptyDir: {}
         {{- end }}
-  {{- if or (and .Values.apiWriter.persistence.data.enabled (not .Values.apiWriter.persistence.data.existingClaim)) (and .Values.apiWriter.persistence.bns.enabled (not .Values.apiWriter.persistence.bns.existingClaim)) }}
+  {{- if and (ne .Values.apiWriter.workloadType "Deployment") (or (and .Values.apiWriter.persistence.data.enabled (not .Values.apiWriter.persistence.data.existingClaim)) (and .Values.apiWriter.persistence.bns.enabled (not .Values.apiWriter.persistence.bns.existingClaim))) }}
   volumeClaimTemplates:
     {{- if and .Values.apiWriter.persistence.data.enabled (not .Values.apiWriter.persistence.data.existingClaim) }}
     - metadata:

--- a/hirosystems/stacks-blockchain-api/values.yaml
+++ b/hirosystems/stacks-blockchain-api/values.yaml
@@ -68,7 +68,7 @@ blockchainNetwork: mainnet
 apiWriter:
   enabled: true
   ## @param apiWriter.workloadType Workload type for API Writer (StatefulSet or Deployment)
-  ## When set to Deployment, volumeClaimTemplates are not used and persistence must be configured via existing claims or disabled
+  ## When set to Deployment, volumeClaimTemplates are not used and separate PVCs will be created and used instead
   ##
   workloadType: StatefulSet
   config:

--- a/hirosystems/stacks-blockchain-api/values.yaml
+++ b/hirosystems/stacks-blockchain-api/values.yaml
@@ -67,6 +67,10 @@ blockchainNetwork: mainnet
 ##
 apiWriter:
   enabled: true
+  ## @param apiWriter.workloadType Workload type for API Writer (StatefulSet or Deployment)
+  ## When set to Deployment, volumeClaimTemplates are not used and persistence must be configured via existing claims or disabled
+  ##
+  workloadType: StatefulSet
   config:
     ## @param dataArchiveUrl Specify a URL from which to download a tar.gz archive of the stacks-blockchain-api TSV file before launching the server
     ##
@@ -117,7 +121,7 @@ apiWriter:
   image:
     registry: docker.io
     repository: hirosystems/stacks-blockchain-api
-    tag: 8.12.0
+    tag: 8.13.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -379,12 +383,13 @@ apiWriter:
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param apiWriter.updateStrategy.type Stacks Blockchain API Writer statefulset strategy type
+  ## @param apiWriter.updateStrategy.type Stacks Blockchain API Writer statefulset/deployment strategy type
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy:
     ## StrategyType
-    ## Can be set to RollingUpdate or OnDelete
+    ## Can be set to RollingUpdate or OnDelete if workloadType is StatefulSet
+    ## Or can be set to RollingUpdate or Recreate if workloadType is Deployment
     ##
     type: RollingUpdate
 
@@ -613,7 +618,7 @@ apiReader:
   image:
     registry: docker.io
     repository: hirosystems/stacks-blockchain-api
-    tag: 8.12.0
+    tag: 8.13.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -972,7 +977,7 @@ apiRosettaReader:
   image:
     registry: docker.io
     repository: hirosystems/stacks-blockchain-api
-    tag: 8.12.0
+    tag: 8.13.2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Closes #50 

* Allows the API writer to be deployed as a Deployment instead of a StatefulSet. This will allow for greater flexibility when a Deployment is preferred.