### PR TITLE
fix(stacks-blockchain-api): don't run security scan on old bitnami image

### DIFF
--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -1,4 +1,8 @@
 annotations:
+  artifacthub.io/images: |
+    - name: bitnami/postgresql
+      image: bitnami/postgresql:15.4.0-debian-11-r45
+      whitelisted: true
   category: ApplicationServer
 apiVersion: v2
 appVersion: 8.12.0


### PR DESCRIPTION
Closes #49 