### PR TITLE
fix(stacks-blockchain-api): fix img helper stacksBlockchainApiEvent…

### DIFF
--- a/hirosystems/stacks-blockchain-api/Chart.yaml
+++ b/hirosystems/stacks-blockchain-api/Chart.yaml
@@ -45,4 +45,4 @@ sources:
   - https://github.com/hirosystems/stacks-blockchain-api
   - https://docs.hiro.so/api
   - https://docs.hiro.so/get-started/stacks-blockchain-api
-version: 6.5.0
+version: 6.5.1

--- a/hirosystems/stacks-blockchain-api/templates/_helpers.tpl
+++ b/hirosystems/stacks-blockchain-api/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Return the name of the Stacks-Blockchain API Event Replay image name used for the download and replay init containers
 */}}
 {{- define "stacksBlockchainApiEventReplay.image" -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.apiWriter.replayEvents.image "global" .Values.global) }}
+{{ include "common.images.image" (dict "imageRoot" .Values.apiWriter.config.replayEvents.image "global" .Values.global) }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
closes https://github.com/hirosystems/devops/issues/2294

this fixes the path of where the helper is referencing the `replayEvents.image` block.